### PR TITLE
[fix] っ(xtsu) alphabet convertion

### DIFF
--- a/jaconv/jaconv.py
+++ b/jaconv/jaconv.py
@@ -215,7 +215,7 @@ def kana2alphabet(text):
         text = list(text)
         tsu_pos = text.index('っ')
         if len(text) <= tsu_pos + 1:
-            return text[:-1] + 'xtsu'
+            return str(text[:-1]) + 'xtsu'
         text[tsu_pos] = text[tsu_pos + 1]
         text = ''.join(text)
     return text


### PR DESCRIPTION
fix bug : about #3 
occur Typeerror when convert a sentence that ends with 'っ' . (example : 'あっ' , 'ぐっ')