### PR TITLE
[fix again] っ(xtsu) alphabet convertion

### DIFF
--- a/jaconv/jaconv.py
+++ b/jaconv/jaconv.py
@@ -215,7 +215,7 @@ def kana2alphabet(text):
         text = list(text)
         tsu_pos = text.index('っ')
         if len(text) <= tsu_pos + 1:
-            return str(text[:-1]) + 'xtsu'
+            return ''.join(text[:-1]) + 'xtsu'
         text[tsu_pos] = text[tsu_pos + 1]
         text = ''.join(text)
     return text

--- a/test_jaconv.py
+++ b/test_jaconv.py
@@ -102,6 +102,8 @@ def test_normalize():
 def test_kana_to_hepburn():
     assert_equal(jaconv.kana2alphabet('まみさん'), 'mamisan')
     assert_equal(jaconv.kana2alphabet('はっとり'), 'hattori')
+    assert_equal(jaconv.kana2alphabet('はっ'), 'haxtsu')
+    assert_equal(jaconv.kana2alphabet('ぽっ'), 'poxtsu')      
 
 
 def test_alphabet2kana():


### PR DESCRIPTION
fix bug : #3 again.
occur Typeerror when convert a sentence that ends with 'っ' . (example : 'あっ' , 'ぐっ')