### PR TITLE
Supprt small kana normalization

### DIFF
--- a/jaconv/__init__.py
+++ b/jaconv/__init__.py
@@ -17,6 +17,7 @@ Usage:
     jaconv.hira2kata(text, [ignore])  # ひらがなを全角カタカナに変換
     jaconv.hira2hkata(text, [ignore])  # ひらがなを半角カタカナに変換
     jaconv.kata2hira(text, [ignore])  # 全角カタカナをひらがなに変換
+    jaconv.enlargesmallkana(text, [ignore])  # 小文字かなを大文字かなに変換
     jaconv.h2z(text, [ignore, kana, ascii, digit])  # 半角文字を全角文字に変換
     jaconv.z2h(text, [ignore, kana, ascii, digit])  # 全角文字を半角文字に変換
     jaconv.han2zen(text, [ignore, kana, ascii, digit])  # 半角文字を全角文字に変換
@@ -34,7 +35,7 @@ __version__ = '0.3'
 __all__ = ['hira2kata', 'hira2hkata', 'kata2hira', 'h2z', 'z2h',
            'hankaku2zenkaku', 'zenkaku2hankaku', 'normalize',
            'kana2alphabet', 'alphabet2kana', 'kata2alphabet', 'alphabet2kata',
-           'hiragana2julius']
+           'hiragana2julius', 'enlargesmallkana']
 
 hira2kata = jaconv.hira2kata
 hira2hkata = jaconv.hira2hkata
@@ -51,3 +52,4 @@ alphabet2kana = jaconv.alphabet2kana
 kata2alphabet = lambda text: jaconv.kana2alphabet(jaconv.kata2hira(text))
 alphabet2kata = lambda text: jaconv.hira2kata(jaconv.alphabet2kana(text))
 hiragana2julius = jaconv.hiragana2julius
+enlargesmallkana = jaconv.enlargesmallkana

--- a/jaconv/conv_table.py
+++ b/jaconv/conv_table.py
@@ -38,6 +38,8 @@ FULL_KANA_SEION = list('ァアィイゥウェエォオカキクケコサシス�
                        'ワヲンーヮヰヱヵヶヽヾ・「」。、')
 HEPBURN = list('aiueoaiueon')
 HEPBURN_KANA = list('ぁぃぅぇぉあいうえおん')
+SMALL_KANA = list('ぁぃぅぇぉゃゅょっァィゥェォャュョッ')
+SMALL_KANA_NORMALIZED = list('あいうえおやゆよつアイウエオヤユヨツ')
 
 
 def _to_ord_list(chars):
@@ -51,6 +53,7 @@ HALF_DIGIT_ORD = _to_ord_list(HALF_DIGIT)
 FULL_DIGIT_ORD = _to_ord_list(FULL_DIGIT)
 HALF_KANA_SEION_ORD = _to_ord_list(HALF_KANA_SEION)
 FULL_KANA_SEION_ORD = _to_ord_list(FULL_KANA_SEION)
+SMALL_KANA_ORD = _to_ord_list(SMALL_KANA)
 
 
 def _to_dict(_from, _to):
@@ -93,6 +96,8 @@ JULIUS_LONG_VOWEL = tuple(
     )
 )
 
+SMALL_KANA2BIG_KANA = _to_dict(SMALL_KANA_ORD, SMALL_KANA_NORMALIZED)
+
 del _to_ord_list
 del _to_dict
 del HIRAGANA_ORD
@@ -114,3 +119,6 @@ del FULL_KANA_SEION_ORD
 del FULL_KANA_SEION
 del HEPBURN
 del HEPBURN_KANA
+del SMALL_KANA
+del SMALL_KANA_ORD
+del SMALL_KANA_NORMALIZED

--- a/jaconv/jaconv.py
+++ b/jaconv/jaconv.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import re
+import typing
 import unicodedata
 from .conv_table import (H2K_TABLE, H2HK_TABLE, K2H_TABLE, H2Z_A, H2Z_AD,
-                         H2Z_AK, H2Z_D, H2Z_K, H2Z_DK, H2Z_ALL, Z2H_A, Z2H_AD,
+                         H2Z_AK, H2Z_D, H2Z_K, H2Z_DK, H2Z_ALL, SMALL_KANA2BIG_KANA, Z2H_A, Z2H_AD,
                          Z2H_AK, Z2H_D, Z2H_K, Z2H_DK, Z2H_ALL, KANA2HEP,
                          HEP2KANA, JULIUS_LONG_VOWEL)
 from .compat import map
@@ -20,6 +21,13 @@ def _exclude_ignorechar(ignore, conv_map):
 
 def _convert(text, conv_map):
     return text.translate(conv_map)
+
+
+def _translate(text: str, ignore: str, conv_map: typing.Dict) -> str:
+    if ignore:
+        _conv_map = _exclude_ignorechar(ignore, conv_map.copy())
+        return _convert(text, _conv_map)
+    return _convert(text, conv_map)
 
 
 def hira2kata(text, ignore=''):
@@ -44,10 +52,7 @@ def hira2kata(text, ignore=''):
     >>> print(jaconv.hira2kata('まどまぎ', ignore='ど'))
     マどマギ
     """
-    if ignore:
-        h2k_map = _exclude_ignorechar(ignore, H2K_TABLE.copy())
-        return _convert(text, h2k_map)
-    return _convert(text, H2K_TABLE)
+    return _translate(text, ignore, H2K_TABLE)
 
 
 def hira2hkata(text, ignore=''):
@@ -72,10 +77,7 @@ def hira2hkata(text, ignore=''):
     >>> print(jaconv.hira2hkata('ともえまみ', ignore='み'))
     ﾄﾓｴﾏみ
     """
-    if ignore:
-        h2hk_map = _exclude_ignorechar(ignore, H2HK_TABLE.copy())
-        return _convert(text, h2hk_map)
-    return _convert(text, H2HK_TABLE)
+    return _translate(text, ignore, H2HK_TABLE)
 
 
 def kata2hira(text, ignore=''):
@@ -100,10 +102,32 @@ def kata2hira(text, ignore=''):
     >>> print(jaconv.kata2hira('マミサン', ignore='ン'))
     まみさン
     """
-    if ignore:
-        k2h_map = _exclude_ignorechar(ignore, K2H_TABLE.copy())
-        return _convert(text, k2h_map)
-    return _convert(text, K2H_TABLE)
+    return _translate(text, ignore, K2H_TABLE)
+
+
+def enlargesmallkana(text: str, ignore: str='') -> str:
+    """Convert small Hiragana or Katakana to normal size
+
+    Parameters
+    ----------
+    text : str
+        Full-width Hiragana or Katakana string.
+    ignore : str
+        Characters to be ignored in converting.
+
+    Return
+    ------
+    str
+        Hiragana or Katakana string, enlarged small Kana
+
+    Examples
+    --------
+    >>> print(jaconv.enlargesmallkana('さくらきょうこ'))
+    さくらきようこ
+    >>> print(jaconv.enlargesmallkana('キュゥべえ'))
+    キユウべえ
+    """
+    return _translate(text, ignore, SMALL_KANA2BIG_KANA)
 
 
 def h2z(text, ignore='', kana=True, ascii=False, digit=False):

--- a/test_jaconv.py
+++ b/test_jaconv.py
@@ -125,3 +125,14 @@ def test_alphabet2julius():
     assert_equal(jaconv.hiragana2julius('かわいいいいい'), 'k a w a i:')
     assert_equal(jaconv.hiragana2julius('やろうぜ'), 'y a r o: z e')
     assert_equal(jaconv.hiragana2julius('てんきすごくいいいいいい'), 't e N k i s u g o k u i:')
+
+def test_yosoku2kana():
+    assert_equal(jaconv.enlargesmallkana('キュゥべえ'), 'キユウべえ')
+    assert_equal(jaconv.enlargesmallkana('しゃえい'), 'しやえい')
+    assert_equal(jaconv.enlargesmallkana('しゅみ'), 'しゆみ')
+    assert_equal(jaconv.enlargesmallkana('きょういっぱい'), 'きよういつぱい')
+    assert_equal(jaconv.enlargesmallkana('シャトー'), 'シヤトー')
+    assert_equal(jaconv.enlargesmallkana('チューリップ'), 'チユーリツプ')
+    assert_equal(jaconv.enlargesmallkana('ショート'), 'シヨート')
+    assert_equal(jaconv.enlargesmallkana('きょういっぱい', 'っ'), 'きよういっぱい')
+    assert_equal(jaconv.enlargesmallkana('きょういっぱい', 'ょっ'), 'きょういっぱい')


### PR DESCRIPTION
## Description
This PR adds support to normalize small Hiragana and Katakana such as `ぁ` and `ッ` to `あ` and `ツ`, respectively.

## Usage
```
>>> print(jaconv.enlargesmallkana('さくらきょうこ'))
さくらきようこ
>>> print(jaconv.enlargesmallkana('キュゥべえ'))
キユウべえ
```
