### PR TITLE
Fix alpha2kana infinite loop bug

### DIFF
--- a/jaconv/jaconv.py
+++ b/jaconv/jaconv.py
@@ -353,6 +353,8 @@ def kana2alphabet(text):
             return ''.join(text[:-1]) + 'xtsu'
         if tsu_pos == 0:
             text[tsu_pos] = 'xtsu'
+        elif text[tsu_pos + 1] == 'っ':
+            text[tsu_pos] = 'xtsu'
         else:
             text[tsu_pos] = text[tsu_pos + 1]
         text = ''.join(text)


### PR DESCRIPTION
Loop was caused by consecutive 'っ' in a  string processed by alpha2kana (Issue 21 raised by user nicoyou).