### PR TITLE
Fix z2h, h2z all flag off bug 

### DIFF
--- a/jaconv/jaconv.py
+++ b/jaconv/jaconv.py
@@ -197,7 +197,10 @@ def h2z(text, ignore='', kana=True, ascii=False, digit=False):
         else:
             h2z_map = H2Z_D
     else:
-        h2z_map = H2Z_K
+        if kana:
+            h2z_map = H2Z_K
+        else:
+            h2z_map = {}  # empty
     if kana:
         text = _conv_dakuten(text)
     if ignore:
@@ -253,7 +256,10 @@ def z2h(text, ignore='', kana=True, ascii=False, digit=False):
         else:
             z2h_map = Z2H_D
     else:
-        z2h_map = Z2H_K
+        if kana:
+            z2h_map = Z2H_K
+        else:
+            z2h_map = {}  # empty
     if ignore:
         z2h_map = _exclude_ignorechar(ignore, z2h_map.copy())
     return _convert(text, z2h_map)

--- a/test_jaconv.py
+++ b/test_jaconv.py
@@ -67,12 +67,15 @@ def test_h2z():
     for ascii in (True, False):
         for digit in (True, False):
             for kana in (True, False):
-                assert_equal(
-                    jaconv.h2z(_concat(HALF_KANA if kana else FULL_KANA,
-                                        HALF_ASCII if ascii else FULL_ASCII,
-                                        HALF_DIGIT if digit else FULL_DIGIT),
-                                ascii=ascii, digit=digit, kana=kana),
-                    _concat(FULL_KANA, FULL_ASCII, FULL_DIGIT))
+                before = _concat(FULL_KANA,  HALF_KANA,
+                                 FULL_ASCII, HALF_ASCII,
+                                 FULL_DIGIT, HALF_DIGIT)
+                after = _concat(FULL_KANA,  FULL_KANA  if kana  else HALF_KANA,
+                                FULL_ASCII, FULL_ASCII if ascii else HALF_ASCII,
+                                FULL_DIGIT, FULL_DIGIT if digit else HALF_DIGIT)
+                converted = jaconv.h2z(before,
+                                       ascii=ascii, digit=digit, kana=kana)
+                assert_equal(converted, after)
 
 
 def test_z2h():
@@ -85,12 +88,15 @@ def test_z2h():
     for ascii in (True, False):
         for digit in (True, False):
             for kana in (True, False):
-                assert_equal(
-                    jaconv.z2h(_concat(FULL_KANA if kana else HALF_KANA,
-                                        FULL_ASCII if ascii else HALF_ASCII,
-                                        FULL_DIGIT if digit else HALF_DIGIT),
-                                ascii=ascii, digit=digit, kana=kana),
-                    _concat(HALF_KANA, HALF_ASCII, HALF_DIGIT))
+                before = _concat(FULL_KANA,  HALF_KANA,
+                                 FULL_ASCII, HALF_ASCII,
+                                 FULL_DIGIT, HALF_DIGIT)
+                after = _concat(HALF_KANA  if kana  else FULL_KANA,  HALF_KANA,
+                                HALF_ASCII if ascii else FULL_ASCII, HALF_ASCII,
+                                HALF_DIGIT if digit else FULL_DIGIT, HALF_DIGIT)
+                converted = jaconv.z2h(before,
+                                       ascii=ascii, digit=digit, kana=kana)
+                assert_equal(converted, after)
 
 
 def test_normalize():


### PR DESCRIPTION
Fixed bug of `h2z(text, kana=False, ascii=False, digit=False)` and `z2h(text, kana=False, ascii=False, digit=False)`.

----
以下、日本語での詳細です。（英語むり）

```python
>>> import jaconv
>>> text = "ｧｱ!Aa0ぁあァア！Ａａ０"
>>> jaconv.h2z(text, kana=False, ascii=False, digit=False)
'ァア!Aa0ぁあァア！Ａａ０'
>>> jaconv.z2h(text, kana=False, ascii=False, digit=False)
'ｧｱ!Aa0ぁあｧｱ！Ａａ０'
```

上記のように指定すると意図しないかな変換が行われてしまいます。
いずれも変換が全く行われずに、入力文字列がそのまま出力文字列になるのが正しいはずです。

各フラグのオンオフを判定している処理中で`ascii`, `digit`が`False`だった際に`kana`の真偽を判定せずにそのまま`True`扱いにしてしまっていたので、`kana`も`False`だった際には空の`dict`を使って変換をする処理を加えました。

----
また、`test_jaconv.py`中の`test_h2z()`, `test_z2h()`で変換対象の文字を正しく変換できているかのテストしか無かったので、変換対象外の文字を誤って変換してしまっていないかのテストも処理中に追加しました。

----
（初めてGitHub使ったので、なにか必要な処理が抜けていたり失礼なことなどしていたら申し訳ないです）