### PR TITLE
Removed typing hints & Docstring improve

### DIFF
--- a/jaconv/conv_table.py
+++ b/jaconv/conv_table.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import re
+import typing
 
 from .compat import map, zip
 
@@ -42,8 +43,9 @@ SMALL_KANA = list('ぁぃぅぇぉゃゅょっァィゥェォヵヶャュョッ'
 SMALL_KANA_NORMALIZED = list('あいうえおやゆよつアイウエオカケヤユヨツ')
 
 
-def _to_ord_list(chars):
+def _to_ord_list(chars: typing.List[str]) -> typing.List[int]:
     return list(map(ord, chars))
+
 
 HIRAGANA_ORD = _to_ord_list(HIRAGANA)
 FULL_KANA_ORD = _to_ord_list(FULL_KANA)
@@ -56,7 +58,8 @@ FULL_KANA_SEION_ORD = _to_ord_list(FULL_KANA_SEION)
 SMALL_KANA_ORD = _to_ord_list(SMALL_KANA)
 
 
-def _to_dict(_from, _to):
+def _to_dict(_from: typing.List[int],
+             _to:   typing.List[str]) -> typing.Dict[int, str]:
     return dict(zip(_from, _to))
 
 

--- a/jaconv/conv_table.py
+++ b/jaconv/conv_table.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import re
-import typing
 
 from .compat import map, zip
 
@@ -43,7 +42,7 @@ SMALL_KANA = list('ぁぃぅぇぉゃゅょっァィゥェォヵヶャュョッ'
 SMALL_KANA_NORMALIZED = list('あいうえおやゆよつアイウエオカケヤユヨツ')
 
 
-def _to_ord_list(chars: typing.List[str]) -> typing.List[int]:
+def _to_ord_list(chars):
     return list(map(ord, chars))
 
 
@@ -58,8 +57,7 @@ FULL_KANA_SEION_ORD = _to_ord_list(FULL_KANA_SEION)
 SMALL_KANA_ORD = _to_ord_list(SMALL_KANA)
 
 
-def _to_dict(_from: typing.List[int],
-             _to:   typing.List[str]) -> typing.Dict[int, str]:
+def _to_dict(_from, _to):
     return dict(zip(_from, _to))
 
 

--- a/jaconv/jaconv.py
+++ b/jaconv/jaconv.py
@@ -38,7 +38,7 @@ def hira2kata(text, ignore=''):
     ----------
     text : str
         Hiragana string.
-    ignore : str
+    ignore : str, optional
         Characters to be ignored in converting.
 
     Return
@@ -63,7 +63,7 @@ def hira2hkata(text, ignore=''):
     ----------
     text : str
         Hiragana string.
-    ignore : str
+    ignore : str, optional
         Characters to be ignored in converting.
 
     Return
@@ -88,7 +88,7 @@ def kata2hira(text, ignore=''):
     ----------
     text : str
         Full-width Katakana string.
-    ignore : str
+    ignore : str, optional
         Characters to be ignored in converting.
 
     Return
@@ -113,7 +113,7 @@ def enlargesmallkana(text: str, ignore: str = '') -> str:
     ----------
     text : str
         Full-width Hiragana or Katakana string.
-    ignore : str
+    ignore : str, optional
         Characters to be ignored in converting.
 
     Return
@@ -138,13 +138,13 @@ def h2z(text, ignore='', kana=True, ascii=False, digit=False):
     ----------
     text : str
         Half-width Katakana string.
-    ignore : str
+    ignore : str, optional
         Characters to be ignored in converting.
-    kana : bool
+    kana : bool, optional
         Either converting Kana or not.
-    ascii : bool
+    ascii : bool, optional
         Either converting ascii or not.
-    digit : bool
+    digit : bool, optional
         Either converting digit or not.
 
     Return
@@ -215,13 +215,13 @@ def z2h(text, ignore='', kana=True, ascii=False, digit=False):
     ----------
     text : str
         Full-width Katakana string.
-    ignore : str
+    ignore : str, optional
         Characters to be ignored in converting.
-    kana : bool
+    kana : bool, optional
         Either converting Kana or not.
-    ascii : bool
+    ascii : bool, optional
         Either converting ascii or not.
-    digit : bool
+    digit : bool, optional
         Either converting digit or not.
 
     Return
@@ -275,7 +275,7 @@ def normalize(text, mode='NFKC'):
     ----------
     text : str
         Source string.
-    mode : str
+    mode : str, optional
         Unicode normalization mode.
 
     Return

--- a/jaconv/jaconv.py
+++ b/jaconv/jaconv.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import re
-import typing
 import unicodedata
 from .conv_table import (H2K_TABLE, H2HK_TABLE, K2H_TABLE, H2Z_A, H2Z_AD,
                          H2Z_AK, H2Z_D, H2Z_K, H2Z_DK, H2Z_ALL,
@@ -14,25 +13,24 @@ consonants = frozenset('sdfghjklqwrtypzxcvbnm')
 ending_h_pattern = re.compile(r'h$')
 
 
-def _exclude_ignorechar(ignore: str,
-                        conv_map: typing.Dict[int, str]) -> typing.Dict[int, str]:
+def _exclude_ignorechar(ignore, conv_map):
     for character in map(ord, ignore):
         del conv_map[character]
     return conv_map
 
 
-def _convert(text: str, conv_map: typing.Dict[int, str]) -> str:
+def _convert(text, conv_map):
     return text.translate(conv_map)
 
 
-def _translate(text: str, ignore: str, conv_map: typing.Dict[int, str]) -> str:
+def _translate(text, ignore, conv_map):
     if ignore:
         _conv_map = _exclude_ignorechar(ignore, conv_map.copy())
         return _convert(text, _conv_map)
     return _convert(text, conv_map)
 
 
-def hira2kata(text: str, ignore: str = '') -> str:
+def hira2kata(text, ignore=''):
     """Convert Hiragana to Full-width (Zenkaku) Katakana.
 
     Parameters
@@ -57,7 +55,7 @@ def hira2kata(text: str, ignore: str = '') -> str:
     return _translate(text, ignore, H2K_TABLE)
 
 
-def hira2hkata(text: str, ignore: str = '') -> str:
+def hira2hkata(text, ignore=''):
     """Convert Hiragana to Half-width (Hankaku) Katakana
 
     Parameters
@@ -82,7 +80,7 @@ def hira2hkata(text: str, ignore: str = '') -> str:
     return _translate(text, ignore, H2HK_TABLE)
 
 
-def kata2hira(text: str, ignore: str = '') -> str:
+def kata2hira(text, ignore=''):
     """Convert Full-width Katakana to Hiragana
 
     Parameters
@@ -107,7 +105,7 @@ def kata2hira(text: str, ignore: str = '') -> str:
     return _translate(text, ignore, K2H_TABLE)
 
 
-def enlargesmallkana(text: str, ignore: str = '') -> str:
+def enlargesmallkana(text, ignore='') -> str:
     """Convert small Hiragana or Katakana to normal size
 
     Parameters
@@ -132,8 +130,7 @@ def enlargesmallkana(text: str, ignore: str = '') -> str:
     return _translate(text, ignore, SMALL_KANA2BIG_KANA)
 
 
-def h2z(text: str, ignore: str = '',
-        kana: bool = True, ascii: bool = False, digit: bool = False) -> str:
+def h2z(text, ignore='', kana=True, ascii=False, digit=False):
     """Convert Half-width (Hankaku) Katakana to Full-width (Zenkaku) Katakana
 
     Parameters
@@ -166,7 +163,7 @@ def h2z(text: str, ignore: str = '',
     １２３４
     """
 
-    def _conv_dakuten(text: str) -> str:
+    def _conv_dakuten(text):
         """Convert Hankaku Dakuten Kana to Zenkaku Dakuten Kana
         """
         text = text.replace("ｶﾞ", "ガ").replace("ｷﾞ", "ギ")
@@ -210,8 +207,7 @@ def h2z(text: str, ignore: str = '',
     return _convert(text, h2z_map)
 
 
-def z2h(text: str, ignore: str = '',
-        kana: bool = True, ascii: bool = False, digit: bool = False) -> str:
+def z2h(text, ignore='', kana=True, ascii=False, digit=False):
     """Convert Full-width (Zenkaku) Katakana to Half-width (Hankaku) Katakana
 
     Parameters
@@ -268,7 +264,7 @@ def z2h(text: str, ignore: str = '',
     return _convert(text, z2h_map)
 
 
-def normalize(text: str, mode: str = 'NFKC') -> str:
+def normalize(text, mode='NFKC'):
     """Convert Half-width (Hankaku) Katakana to Full-width (Zenkaku) Katakana,
     Full-width (Zenkaku) ASCII and DIGIT to Half-width (Hankaku) ASCII
     and DIGIT.
@@ -309,7 +305,7 @@ def normalize(text: str, mode: str = 'NFKC') -> str:
     return unicodedata.normalize(mode, text)
 
 
-def kana2alphabet(text: str) -> str:
+def kana2alphabet(text):
     """Convert Hiragana to hepburn-style alphabets
 
     Parameters
@@ -380,7 +376,7 @@ def kana2alphabet(text: str) -> str:
     return text
 
 
-def alphabet2kana(text: str) -> str:
+def alphabet2kana(text):
     """Convert alphabets to Hiragana
 
     Parameters
@@ -527,7 +523,7 @@ def alphabet2kana(text: str) -> str:
     return ''.join(ret)
 
 
-def hiragana2julius(text: str) -> str:
+def hiragana2julius(text):
     """Convert Hiragana to Julius's phoneme format.
 
     Parameters

--- a/jaconv/jaconv.py
+++ b/jaconv/jaconv.py
@@ -363,17 +363,17 @@ def kana2alphabet(text):
     text = text.replace('ゑ', 'we')
     text = _convert(text, KANA2HEP)
     while 'っ' in text:
-        text = list(text)
-        tsu_pos = text.index('っ')
-        if len(text) <= tsu_pos + 1:
-            return ''.join(text[:-1]) + 'xtsu'
+        chars = list(text)
+        tsu_pos = chars.index('っ')
+        if len(chars) <= tsu_pos + 1:
+            return ''.join(chars[:-1]) + 'xtsu'
         if tsu_pos == 0:
-            text[tsu_pos] = 'xtsu'
-        elif text[tsu_pos + 1] == 'っ':
-            text[tsu_pos] = 'xtsu'
+            chars[tsu_pos] = 'xtsu'
+        elif chars[tsu_pos + 1] == 'っ':
+            chars[tsu_pos] = 'xtsu'
         else:
-            text[tsu_pos] = text[tsu_pos + 1]
-        text = ''.join(text)
+            chars[tsu_pos] = chars[tsu_pos + 1]
+        text = ''.join(chars)
     return text
 
 

--- a/jaconv/jaconv.py
+++ b/jaconv/jaconv.py
@@ -14,24 +14,25 @@ consonants = frozenset('sdfghjklqwrtypzxcvbnm')
 ending_h_pattern = re.compile(r'h$')
 
 
-def _exclude_ignorechar(ignore, conv_map):
+def _exclude_ignorechar(ignore: str,
+                        conv_map: typing.Dict[int, str]) -> typing.Dict[int, str]:
     for character in map(ord, ignore):
         del conv_map[character]
     return conv_map
 
 
-def _convert(text, conv_map):
+def _convert(text: str, conv_map: typing.Dict[int, str]) -> str:
     return text.translate(conv_map)
 
 
-def _translate(text: str, ignore: str, conv_map: typing.Dict) -> str:
+def _translate(text: str, ignore: str, conv_map: typing.Dict[int, str]) -> str:
     if ignore:
         _conv_map = _exclude_ignorechar(ignore, conv_map.copy())
         return _convert(text, _conv_map)
     return _convert(text, conv_map)
 
 
-def hira2kata(text, ignore=''):
+def hira2kata(text: str, ignore: str = '') -> str:
     """Convert Hiragana to Full-width (Zenkaku) Katakana.
 
     Parameters
@@ -56,7 +57,7 @@ def hira2kata(text, ignore=''):
     return _translate(text, ignore, H2K_TABLE)
 
 
-def hira2hkata(text, ignore=''):
+def hira2hkata(text: str, ignore: str = '') -> str:
     """Convert Hiragana to Half-width (Hankaku) Katakana
 
     Parameters
@@ -81,7 +82,7 @@ def hira2hkata(text, ignore=''):
     return _translate(text, ignore, H2HK_TABLE)
 
 
-def kata2hira(text, ignore=''):
+def kata2hira(text: str, ignore: str = '') -> str:
     """Convert Full-width Katakana to Hiragana
 
     Parameters
@@ -131,7 +132,8 @@ def enlargesmallkana(text: str, ignore: str = '') -> str:
     return _translate(text, ignore, SMALL_KANA2BIG_KANA)
 
 
-def h2z(text, ignore='', kana=True, ascii=False, digit=False):
+def h2z(text: str, ignore: str = '',
+        kana: bool = True, ascii: bool = False, digit: bool = False) -> str:
     """Convert Half-width (Hankaku) Katakana to Full-width (Zenkaku) Katakana
 
     Parameters
@@ -164,7 +166,7 @@ def h2z(text, ignore='', kana=True, ascii=False, digit=False):
     １２３４
     """
 
-    def _conv_dakuten(text):
+    def _conv_dakuten(text: str) -> str:
         """Convert Hankaku Dakuten Kana to Zenkaku Dakuten Kana
         """
         text = text.replace("ｶﾞ", "ガ").replace("ｷﾞ", "ギ")
@@ -208,7 +210,8 @@ def h2z(text, ignore='', kana=True, ascii=False, digit=False):
     return _convert(text, h2z_map)
 
 
-def z2h(text, ignore='', kana=True, ascii=False, digit=False):
+def z2h(text: str, ignore: str = '',
+        kana: bool = True, ascii: bool = False, digit: bool = False) -> str:
     """Convert Full-width (Zenkaku) Katakana to Half-width (Hankaku) Katakana
 
     Parameters
@@ -265,7 +268,7 @@ def z2h(text, ignore='', kana=True, ascii=False, digit=False):
     return _convert(text, z2h_map)
 
 
-def normalize(text, mode='NFKC'):
+def normalize(text: str, mode: str = 'NFKC') -> str:
     """Convert Half-width (Hankaku) Katakana to Full-width (Zenkaku) Katakana,
     Full-width (Zenkaku) ASCII and DIGIT to Half-width (Hankaku) ASCII
     and DIGIT.
@@ -306,7 +309,7 @@ def normalize(text, mode='NFKC'):
     return unicodedata.normalize(mode, text)
 
 
-def kana2alphabet(text):
+def kana2alphabet(text: str) -> str:
     """Convert Hiragana to hepburn-style alphabets
 
     Parameters
@@ -377,7 +380,7 @@ def kana2alphabet(text):
     return text
 
 
-def alphabet2kana(text):
+def alphabet2kana(text: str) -> str:
     """Convert alphabets to Hiragana
 
     Parameters
@@ -524,7 +527,7 @@ def alphabet2kana(text):
     return ''.join(ret)
 
 
-def hiragana2julius(text):
+def hiragana2julius(text: str) -> str:
     """Convert Hiragana to Julius's phoneme format.
 
     Parameters

--- a/jaconv/jaconv.py
+++ b/jaconv/jaconv.py
@@ -16,7 +16,7 @@ ending_h_pattern = re.compile(r'h$')
 
 def _exclude_ignorechar(ignore, conv_map):
     for character in map(ord, ignore):
-        conv_map[character] = character
+        del conv_map[character]
     return conv_map
 
 


### PR DESCRIPTION
- Add a keyword "optional" to optional arguments in docstring
- _exclude_ignorechar(): Improved process of removing ignore chars from map
- Removed typing hints for Python < 3.5
(resolved #24)
- Improved some process

----
以下、日本語です。

- docstring中のデフォルト引数を持つ引数に"optional"表記が無かったので加えました
- `_exclude_ignorechar()` 中で無視する文字を除外する処理を向上しました
  - 元は置換 `'A'`⇒`'A'` をしていましたが、`'A'`を辞書から削除するようにしました
- `typing`が要Python3.5以上であるため`typing`を除去しました
- `typing`を除去する前に全関数に`typing`を追加し、一部わかりにくい処理などがあったため改善しました
  - 型がおかしい処理等はありませんでした

[公式リファレンス](https://docs.python.org/ja/3/library/typing.html)によると、`typing`はPython3.5で追加されたそうです。
Python2.7.18で`import jaconv`して確認したところ`SyntaxError`となっていました。
