### PR TITLE
Support uppercase romanji

### DIFF
--- a/jaconv/jaconv.py
+++ b/jaconv/jaconv.py
@@ -394,6 +394,8 @@ def alphabet2kana(text):
     >>> print(jaconv.alphabet2kana('mamisan'))
     まみさん
     """
+    text = text.lower()  # ensure lower case.
+  
     # replace final h with う, e.g., Itoh -> いとう
     text = re.sub(ending_h_pattern, 'う', text)
 


### PR DESCRIPTION
Bug: 

```
    from jaconv import alphabet2kana
    print(alphabet2kana("A"))
    > A
    print(alphabet2kana("a"))
    > あ
```

Fix: 

call "lower()" at the start of the function.