### PR TITLE
migrate testsuite to pytest

### DIFF
--- a/test_jaconv.py
+++ b/test_jaconv.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from nose.tools import assert_equal, nottest
 import jaconv
 from functools import partial
 
-assert_equal.__self__.maxDiff = None
 
 HIRAGANA = ('ぁあぃいぅうぇえぉおかがきぎくぐけげこごさざしじすずせぜそぞた',
             'だちぢっつづてでとどなにぬねのはばぱひびぴふぶぷへべぺほぼぽま',
@@ -25,13 +23,11 @@ FULL_ASCII = ('！＂＃＄％＆＇（）＊＋，－．／：；＜＝＞？�
 FULL_DIGIT = '０１２３４５６７８９'
 
 
-@nottest
 def _compare(mathod, lhs, rhs):
     for i in range(len(lhs)):
-        assert_equal(mathod(lhs[i]), rhs[i])
+        assert mathod(lhs[i]) == rhs[i]
 
 
-@nottest
 def _concat(*iterables):
     result = ''
     for iterable in iterables:
@@ -40,26 +36,26 @@ def _concat(*iterables):
 
 
 def test_hira2kata():
-    assert_equal(jaconv.hira2kata('ともえまみ'), 'トモエマミ')
-    assert_equal(jaconv.hira2kata('まどまぎ', ignore='ど'), 'マどマギ')
+    assert jaconv.hira2kata('ともえまみ') == 'トモエマミ'
+    assert jaconv.hira2kata('まどまぎ', ignore='ど') == 'マどマギ'
     _compare(jaconv.hira2kata, HIRAGANA, FULL_KANA)
 
 
 def test_hira2hkata():
-    assert_equal(jaconv.hira2hkata('ともえまみ'), 'ﾄﾓｴﾏﾐ')
-    assert_equal(jaconv.hira2hkata('ともえまみ', ignore='み'), 'ﾄﾓｴﾏみ')
+    assert jaconv.hira2hkata('ともえまみ') == 'ﾄﾓｴﾏﾐ'
+    assert jaconv.hira2hkata('ともえまみ', ignore='み') == 'ﾄﾓｴﾏみ'
     _compare(jaconv.hira2hkata, HIRAGANA, HALF_KANA)
 
 
 def test_kata2hira():
-    assert_equal(jaconv.kata2hira('巴マミ'), '巴まみ')
-    assert_equal(jaconv.kata2hira('マミサン', ignore='ン'), 'まみさン')
+    assert jaconv.kata2hira('巴マミ') == '巴まみ'
+    assert jaconv.kata2hira('マミサン', ignore='ン') == 'まみさン'
     _compare(jaconv.kata2hira, FULL_KANA, HIRAGANA)
 
 
 def test_h2z():
-    assert_equal(jaconv.h2z('ﾃｨﾛﾌｨﾅｰﾚ'), 'ティロフィナーレ')
-    assert_equal(jaconv.h2z('ﾃｨﾛﾌｨﾅｰﾚ', ignore='ｨ'), 'テｨロフｨナーレ')
+    assert jaconv.h2z('ﾃｨﾛﾌｨﾅｰﾚ') == 'ティロフィナーレ'
+    assert jaconv.h2z('ﾃｨﾛﾌｨﾅｰﾚ', ignore='ｨ') == 'テｨロフｨナーレ'
     _compare(jaconv.h2z, HALF_KANA, FULL_KANA)
     _compare(partial(jaconv.h2z, ascii=True), HALF_ASCII, FULL_ASCII)
     _compare(partial(jaconv.h2z, digit=True), HALF_DIGIT, FULL_DIGIT)
@@ -75,12 +71,12 @@ def test_h2z():
                                 FULL_DIGIT, FULL_DIGIT if digit else HALF_DIGIT)
                 converted = jaconv.h2z(before,
                                        ascii=ascii, digit=digit, kana=kana)
-                assert_equal(converted, after)
+                assert converted == after
 
 
 def test_z2h():
-    assert_equal(jaconv.z2h('ティロフィナーレ'), 'ﾃｨﾛﾌｨﾅｰﾚ')
-    assert_equal(jaconv.z2h('ティロフィナーレ', ignore='ィ'), 'ﾃィﾛﾌィﾅｰﾚ')
+    assert jaconv.z2h('ティロフィナーレ') == 'ﾃｨﾛﾌｨﾅｰﾚ'
+    assert jaconv.z2h('ティロフィナーレ', ignore='ィ') == 'ﾃィﾛﾌィﾅｰﾚ'
     _compare(partial(jaconv.z2h, kana=True), FULL_KANA, HALF_KANA)
     _compare(partial(jaconv.z2h, ascii=True), FULL_ASCII, HALF_ASCII)
     _compare(partial(jaconv.z2h, digit=True), FULL_DIGIT, HALF_DIGIT)
@@ -96,51 +92,50 @@ def test_z2h():
                                 HALF_DIGIT if digit else FULL_DIGIT, HALF_DIGIT)
                 converted = jaconv.z2h(before,
                                        ascii=ascii, digit=digit, kana=kana)
-                assert_equal(converted, after)
+                assert converted == after
 
 
 def test_normalize():
-    assert_equal(jaconv.normalize('ﾃｨﾛ･フィナ〜レ', 'NFKC'), 'ティロ・フィナーレ')
-    assert_equal(jaconv.normalize(_concat(HALF_KANA, FULL_DIGIT), 'NFKC'),
-                 ''.join(FULL_KANA)+''.join(HALF_DIGIT))
+    assert jaconv.normalize('ﾃｨﾛ･フィナ〜レ', 'NFKC') == 'ティロ・フィナーレ'
+    assert jaconv.normalize(_concat(HALF_KANA, FULL_DIGIT), 'NFKC') == ''.join(FULL_KANA)+''.join(HALF_DIGIT)
 
 
 def test_kana2alphabet():
-    assert_equal(jaconv.kana2alphabet('まみさん'), 'mamisan')
-    assert_equal(jaconv.kana2alphabet('はっとり'), 'hattori')
-    assert_equal(jaconv.kana2alphabet('はっ'), 'haxtsu')
-    assert_equal(jaconv.kana2alphabet('ぽっ'), 'poxtsu')
-    assert_equal(jaconv.kana2alphabet('ふぁふぃふぇふぉ'), 'fafifefo')
-    assert_equal(jaconv.kana2alphabet('っって'), 'xtsutte')
+    assert jaconv.kana2alphabet('まみさん') == 'mamisan'
+    assert jaconv.kana2alphabet('はっとり') == 'hattori'
+    assert jaconv.kana2alphabet('はっ') == 'haxtsu'
+    assert jaconv.kana2alphabet('ぽっ') == 'poxtsu'
+    assert jaconv.kana2alphabet('ふぁふぃふぇふぉ') == 'fafifefo'
+    assert jaconv.kana2alphabet('っって') == 'xtsutte'
 
 
 def test_alphabet2kana():
-    assert_equal(jaconv.alphabet2kana('mamisan'), 'まみさん')
-    assert_equal(jaconv.alphabet2kana('doggu doguu'), 'どっぐ どぐう')
-    assert_equal(jaconv.alphabet2kana('botchi'), 'ぼっち')
-    assert_equal(jaconv.alphabet2kana('fainarufantaji-'), 'ふぁいなるふぁんたじー')
-    assert_equal(jaconv.alphabet2kana('atsui'), 'あつい')
-    assert_equal(jaconv.alphabet2kana('itoh'), 'いとう')
-    assert_equal(jaconv.alphabet2kana('ohtaku'), 'おおたく')
-    assert_equal(jaconv.alphabet2kana('namba'), 'なんば')
+    assert jaconv.alphabet2kana('mamisan') == 'まみさん'
+    assert jaconv.alphabet2kana('doggu doguu') == 'どっぐ どぐう'
+    assert jaconv.alphabet2kana('botchi') == 'ぼっち'
+    assert jaconv.alphabet2kana('fainarufantaji-') == 'ふぁいなるふぁんたじー'
+    assert jaconv.alphabet2kana('atsui') == 'あつい'
+    assert jaconv.alphabet2kana('itoh') == 'いとう'
+    assert jaconv.alphabet2kana('ohtaku') == 'おおたく'
+    assert jaconv.alphabet2kana('namba') == 'なんば'
 
 
 def test_alphabet2julius():
-    assert_equal(jaconv.hiragana2julius('てんき'), 't e N k i')
-    assert_equal(jaconv.hiragana2julius('やったー'), 'y a q t a:')
-    assert_equal(jaconv.hiragana2julius('かわいいいいい'), 'k a w a i:')
-    assert_equal(jaconv.hiragana2julius('やろうぜ'), 'y a r o: z e')
-    assert_equal(jaconv.hiragana2julius('てんきすごくいいいいいい'), 't e N k i s u g o k u i:')
+    assert jaconv.hiragana2julius('てんき') == 't e N k i'
+    assert jaconv.hiragana2julius('やったー') == 'y a q t a:'
+    assert jaconv.hiragana2julius('かわいいいいい') == 'k a w a i:'
+    assert jaconv.hiragana2julius('やろうぜ') == 'y a r o: z e'
+    assert jaconv.hiragana2julius('てんきすごくいいいいいい') == 't e N k i s u g o k u i:'
 
 def test_enlargesmallkana():
-    assert_equal(jaconv.enlargesmallkana('キュゥべえ'), 'キユウべえ')
-    assert_equal(jaconv.enlargesmallkana('しゃえい'), 'しやえい')
-    assert_equal(jaconv.enlargesmallkana('しゅみ'), 'しゆみ')
-    assert_equal(jaconv.enlargesmallkana('きょういっぱい'), 'きよういつぱい')
-    assert_equal(jaconv.enlargesmallkana('霞ヶ関'), '霞ケ関')
-    assert_equal(jaconv.enlargesmallkana('一ヵ月'), '一カ月')
-    assert_equal(jaconv.enlargesmallkana('シャトー'), 'シヤトー')
-    assert_equal(jaconv.enlargesmallkana('チューリップ'), 'チユーリツプ')
-    assert_equal(jaconv.enlargesmallkana('ショート'), 'シヨート')
-    assert_equal(jaconv.enlargesmallkana('きょういっぱい', 'っ'), 'きよういっぱい')
-    assert_equal(jaconv.enlargesmallkana('きょういっぱい', 'ょっ'), 'きょういっぱい')
+    assert jaconv.enlargesmallkana('キュゥべえ') == 'キユウべえ'
+    assert jaconv.enlargesmallkana('しゃえい') == 'しやえい'
+    assert jaconv.enlargesmallkana('しゅみ') == 'しゆみ'
+    assert jaconv.enlargesmallkana('きょういっぱい') == 'きよういつぱい'
+    assert jaconv.enlargesmallkana('霞ヶ関') == '霞ケ関'
+    assert jaconv.enlargesmallkana('一ヵ月') == '一カ月'
+    assert jaconv.enlargesmallkana('シャトー') == 'シヤトー'
+    assert jaconv.enlargesmallkana('チューリップ') == 'チユーリツプ'
+    assert jaconv.enlargesmallkana('ショート') == 'シヨート'
+    assert jaconv.enlargesmallkana('きょういっぱい', 'っ') == 'きよういっぱい'
+    assert jaconv.enlargesmallkana('きょういっぱい', 'ょっ') == 'きょういっぱい'


### PR DESCRIPTION
nose is deprecated and abandoned and doesn't work on modern python versions. It isn't packaged by distros and installing it successfully installs a broken "nosetests" command that doesn't work with python 3.10 and on.

pytest has automatic support for sugaring asserts without special syntax, and automatic support for not treating non-test functions as tests. It works great and without any effort. Let's use it. :)