### PR TITLE
Add a test file into source tar ball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include *.rst
 include LICENSE
+include test_jaconv.py


### PR DESCRIPTION
Test files are recommended for source tar ball because they are required to check the codes works in every time.

Test files will not embed into binary packages even if with this fix.