### PR TITLE
fix: romanize small ka/ke in kana2alphabet

### DIFF
--- a/jaconv/jaconv.py
+++ b/jaconv/jaconv.py
@@ -411,7 +411,10 @@ def kana2alphabet(text):
     text = text.replace('ぇ', 'e').replace('ぉ', 'o')
     text = text.replace('ゎ', 'wa')
     text = text.replace('ゔ', 'vu')
-    text = text.replace('ヵ', 'ka')  # Strictly, it's kanji, not kana.
+    # Small ka/ke (strictly kanji, not kana), plus their hiragana forms,
+    # which kata2hira produces from ヵ/ヶ.
+    text = text.replace('ヵ', 'ka').replace('ヶ', 'ke')
+    text = text.replace('ゕ', 'ka').replace('ゖ', 'ke')
     text = _convert(text, KANA2HEP)
     while 'っ' in text:
         chars = list(text)

--- a/test_jaconv.py
+++ b/test_jaconv.py
@@ -145,6 +145,21 @@ def test_kana2alphabet():
     assert jaconv.kana2alphabet('きゅ') == 'kyu'
     assert jaconv.kana2alphabet('りゅう') == 'ryuu'
 
+    # Small ka/ke must not leak into the output as raw kana.
+    # The katakana small ka was already handled (ヵ -> ka); its small-ke
+    # sibling and both hiragana forms (ゕ/ゖ) were not.
+    assert jaconv.kana2alphabet('ヵ') == 'ka'
+    assert jaconv.kana2alphabet('ヶ') == 'ke'
+    assert jaconv.kana2alphabet('ゕ') == 'ka'
+    assert jaconv.kana2alphabet('ゖ') == 'ke'
+
+
+def test_kata2alphabet_small_kake():
+    # kata2alphabet routes through kata2hira, which maps ヵ/ヶ to ゕ/ゖ,
+    # so the hiragana small ka/ke must be romanized too.
+    assert jaconv.kata2alphabet('ヵ') == 'ka'
+    assert jaconv.kata2alphabet('ヶ') == 'ke'
+
 
 def text_kata2alphabet():
     assert jaconv.kata2alphabet('マミサン') == 'mamisan'


### PR DESCRIPTION
`kana2alphabet` romanizes the small-ka katakana (`ヵ` -> `ka`, added in #44) but leaves its small-ke sibling `ヶ` and both hiragana forms (`ゕ`, `ゖ`) in the output as raw kana:

```python
>>> jaconv.kana2alphabet('ヶ')
'ヶ'        # expected 'ke'
>>> jaconv.kata2alphabet('ヶ')
'ゖ'        # expected 'ke'
>>> jaconv.kata2alphabet('ヵ')
'ゕ'        # expected 'ka'
```

`kata2alphabet` runs `kata2hira` first, which maps `ヵ`/`ヶ` to the hiragana `ゕ`/`ゖ`, so even the `ヵ` that #44 added is left untouched when it is reached through `kata2alphabet`.

The fix completes the small ka/ke family the same way #44 handled `ヵ`:

```python
text = text.replace('ヵ', 'ka').replace('ヶ', 'ke')
text = text.replace('ゕ', 'ka').replace('ゖ', 'ke')
```

`ka`/`ke` is consistent with the rest of the library: `enlarge_smallkana` normalizes `ヵ` -> `カ` and `ヶ` -> `ケ`, and `alphabet2kana` already maps `xka`/`xke` back to `ヵ`/`ヶ`.

Added assertions to `test_kana2alphabet` and a small `test_kata2alphabet_small_kake`. Without the source change they fail (`assert 'ヶ' == 'ke'`, `assert 'ゕ' == 'ka'`); with it the full suite passes.
